### PR TITLE
feat: #1 사용자 인증/인가 시스템 기능 구현 및 개선

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.38/57f8f5e02e92a30fd21b80cbd426a4172b5f8e29/lombok-1.18.38.jar" />
+        </processorPath>
+        <module name="server.main" />
+      </profile>
+    </annotationProcessing>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="server" options="-parameters" />
+      <module name="server.main" options="-parameters" />
+      <module name="server.test" options="-parameters" />
+    </option>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="delegatedBuild" value="false" />
+        <option name="testRunner" value="PLATFORM" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$/server" />
+        <option name="gradleJvm" value="liberica-17" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/server" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="openjdk-24" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/oba_backend_old.iml" filepath="$PROJECT_DIR$/.idea/oba_backend_old.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/oba_backend_old.iml
+++ b/.idea/oba_backend_old.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -24,12 +24,27 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // MySQL 라인을 추가
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Lombok (편의성)
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // JWT Library (jjwt)
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/oba/backend/server/ServerApplication.java
+++ b/server/src/main/java/oba/backend/server/ServerApplication.java
@@ -10,5 +10,4 @@ public class ServerApplication {
 		SpringApplication.run(ServerApplication.class, args);
 		System.out.println(1);
 	}
-
 }

--- a/server/src/main/java/oba/backend/server/config/SecurityConfig.java
+++ b/server/src/main/java/oba/backend/server/config/SecurityConfig.java
@@ -1,4 +1,74 @@
 package oba.backend.server.config;
 
+import lombok.RequiredArgsConstructor;
+import oba.backend.server.jwt.JwtAuthenticationFilter;
+import oba.backend.server.jwt.JwtProvider;
+import oba.backend.server.security.CustomUserDetailsService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtProvider jwtProvider;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(customUserDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    /**
+     * Spring Security의 필터 체인을 설정합니다.
+     * @param http HttpSecurity 객체
+     * @return 구성된 SecurityFilterChain
+     * @throws Exception 설정 중 발생할 수 있는 예외
+     */
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // CSRF(Cross-Site Request Forgery) 보호 기능을 비활성화합니다. (Stateless JWT 인증에서는 불필요)
+                .csrf(csrf -> csrf.disable())
+                // 세션을 사용하지 않는 Stateless 정책을 설정합니다.
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // HTTP 요청에 대한 인가 규칙을 설정합니다.
+                .authorizeHttpRequests(authorize -> authorize
+                        // 가장 최신의 권장 방식은 URL 패턴 문자열을 직접 사용하는 것입니다.
+                        .requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/reissue").permitAll()
+                        // 위에서 지정한 URL 외의 모든 요청은 인증을 받아야 합니다.
+                        .anyRequest().authenticated()
+                )
+                // 커스텀 AuthenticationProvider를 등록합니다.
+                .authenticationProvider(authenticationProvider())
+                // UsernamePasswordAuthenticationFilter 앞에 직접 만든 JwtAuthenticationFilter를 추가합니다.
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
 }

--- a/server/src/main/java/oba/backend/server/controller/AuthController.java
+++ b/server/src/main/java/oba/backend/server/controller/AuthController.java
@@ -1,4 +1,72 @@
 package oba.backend.server.controller;
 
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import oba.backend.server.dto.AuthDto.LoginRequest;
+import oba.backend.server.dto.AuthDto.ReissueRequest;
+import oba.backend.server.dto.AuthDto.SignUpRequest;
+import oba.backend.server.dto.AuthDto.TokenResponse;
+import oba.backend.server.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * 회원가입 API
+     * @param signUpRequest 아이디, 비밀번호
+     * @return 성공 메시지
+     */
+    @PostMapping("/signup")
+    public ResponseEntity<String> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
+        authService.signUp(signUpRequest);
+        return ResponseEntity.ok("회원가입이 성공적으로 완료되었습니다.");
+    }
+
+    /**
+     * 회원 탈퇴 API
+     * @return 성공 메시지
+     */
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<String> withdraw() {
+        authService.deleteMember();
+        return ResponseEntity.ok("성공적으로 회원 탈퇴되었습니다.");
+    }
+
+    /**
+     * 로그인 API
+     * @param loginRequest 아이디, 비밀번호
+     * @return Access Token, Refresh Token
+     */
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest loginRequest) {
+        TokenResponse tokenResponse = authService.login(loginRequest);
+        return ResponseEntity.ok(tokenResponse);
+    }
+
+    /**
+     * 토큰 재발급 API
+     * @param reissueRequest 기존 Refresh Token
+     * @return 새로운 Access Token, Refresh Token
+     */
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenResponse> reissue(@RequestBody ReissueRequest reissueRequest) {
+        TokenResponse tokenResponse = authService.reissue(reissueRequest.refreshToken());
+        return ResponseEntity.ok(tokenResponse);
+    }
+
+    /**
+     * 로그아웃 API
+     * @return 성공 메시지
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout() {
+        authService.logout();
+        return ResponseEntity.ok("성공적으로 로그아웃되었습니다.");
+    }
 }

--- a/server/src/main/java/oba/backend/server/dto/AuthDto.java
+++ b/server/src/main/java/oba/backend/server/dto/AuthDto.java
@@ -1,4 +1,47 @@
 package oba.backend.server.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 public class AuthDto {
+
+    // 회원가입 요청 DTO
+    public record SignUpRequest(
+            @NotBlank(message = "이메일은 필수 입력 값입니다.")
+            @Email(message = "유효한 이메일 형식이 아닙니다.")
+            String email,
+
+            @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+            @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.")
+            String nickname,
+
+            @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+            @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}",
+                    message = "비밀번호는 영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상씩 포함된 8자 ~ 20자의 비밀번호여야 합니다.")
+            String password
+    ) {
+    }
+
+    // 로그인 요청 DTO (username -> email)
+    public record LoginRequest(
+            @NotBlank @Email String email,
+            @NotBlank String password
+    ) {
+    }
+
+    // 토큰 정보 DTO (변경 없음)
+    public record TokenResponse(
+            String grantType,
+            String accessToken,
+            String refreshToken
+    ) {
+    }
+
+    // 토큰 갱신 요청 DTO (변경 없음)
+    public record ReissueRequest(
+            @NotBlank String refreshToken
+    ) {
+    }
 }

--- a/server/src/main/java/oba/backend/server/entity/Member.java
+++ b/server/src/main/java/oba/backend/server/entity/Member.java
@@ -1,4 +1,50 @@
 package oba.backend.server.entity;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 'username' 대신 'email'을 사용하고, 고유해야 합니다.
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    // 화면에 표시될 닉네임을 추가합니다.
+    @Column(unique = true, nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String password;
+
+    private String refreshToken;
+
+    @Column(nullable = false)
+    private boolean isWithdrawn = false;
+
+    @Builder
+    public Member(String email, String nickname, String password) {
+        this.email = email;
+        this.nickname = nickname;
+        this.password = password;
+        this.isWithdrawn = false;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void withdraw() {
+        this.isWithdrawn = true;
+        this.refreshToken = null;
+    }
 }

--- a/server/src/main/java/oba/backend/server/jwt/JwtAuthenticationFilter.java
+++ b/server/src/main/java/oba/backend/server/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,60 @@
 package oba.backend.server.jwt;
 
-public class JwtAuthenticationFilter {
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT 인증 필터
+ * 클라이언트 요청 시 JWT 인증을 하기 위해 만든 필터입니다.
+ * OncePerRequestFilter를 상속받아 요청당 한 번만 실행되도록 보장합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    // 실제 필터링 로직을 수행하는 메소드
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // 1. Request Header에서 JWT 토큰 추출
+        String token = resolveToken(request);
+
+        // 2. validateToken 으로 토큰 유효성 검사
+        if (token != null && jwtProvider.validateToken(token)) {
+            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 받아옴
+            Authentication authentication = jwtProvider.getAuthentication(token);
+            // SecurityContext 에 Authentication 객체를 저장
+            // 이 과정을 통해 Spring Security는 현재 요청을 처리하는 스레드에서 사용자가 인증되었다고 인식합니다.
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        // 다음 필터로 제어를 넘깁니다.
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Request Header에서 토큰 정보를 추출하는 메소드
+     * @param request HttpServletRequest 객체
+     * @return 추출된 토큰 문자열
+     */
+    private String resolveToken(HttpServletRequest request) {
+        // "Authorization" 헤더에서 토큰을 가져옵니다.
+        String bearerToken = request.getHeader("Authorization");
+        // 토큰이 존재하고 "Bearer "로 시작하는지 확인합니다.
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            // "Bearer " 접두어를 제거하고 순수한 토큰 값만 반환합니다.
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
 }

--- a/server/src/main/java/oba/backend/server/jwt/JwtProvider.java
+++ b/server/src/main/java/oba/backend/server/jwt/JwtProvider.java
@@ -1,4 +1,109 @@
 package oba.backend.server.jwt;
 
+import oba.backend.server.dto.AuthDto.TokenResponse;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
 public class JwtProvider {
+
+    private final Key key;
+    private final long accessTokenExpirationMs;
+    private final long refreshTokenExpirationMs;
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-expiration-ms}") long accessTokenExpirationMs,
+            @Value("${jwt.refresh-token-expiration-ms}") long refreshTokenExpirationMs) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpirationMs = accessTokenExpirationMs;
+        this.refreshTokenExpirationMs = refreshTokenExpirationMs;
+    }
+
+    // 인증 정보를 기반으로 Access Token과 Refresh Token 생성
+    public TokenResponse generateToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        // Access Token 생성 (동일)
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(new Date(now + accessTokenExpirationMs))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // Refresh Token 생성 시 subject(사용자 이름) 제거
+        String refreshToken = Jwts.builder()
+                // .setSubject(authentication.getName()) // <<< 이 줄을 삭제합니다.
+                .setExpiration(new Date(now + refreshTokenExpirationMs))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return new TokenResponse("Bearer", accessToken, refreshToken);
+    }
+
+    // JWT 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("auth").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+
+    // 토큰 정보를 검증하는 메서드
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
 }

--- a/server/src/main/java/oba/backend/server/repository/MemberRepository.java
+++ b/server/src/main/java/oba/backend/server/repository/MemberRepository.java
@@ -1,4 +1,20 @@
 package oba.backend.server.repository;
 
-public interface MemberRepository {
+import oba.backend.server.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    // email로 탈퇴하지 않은 사용자 조회 (로그인 등에서 사용)
+    Optional<Member> findByEmailAndIsWithdrawnFalse(String email);
+
+    // email로 모든 사용자 조회 (회원가입 시 중복 검사용)
+    Optional<Member> findByEmail(String email);
+
+    // nickname으로 모든 사용자 조회 (회원가입 시 중복 검사용)
+    Optional<Member> findByNickname(String nickname);
+
+    // refreshToken으로 탈퇴하지 않은 사용자 조회
+    Optional<Member> findByRefreshTokenAndIsWithdrawnFalse(String refreshToken);
 }

--- a/server/src/main/java/oba/backend/server/security/CustomUserDetailsService.java
+++ b/server/src/main/java/oba/backend/server/security/CustomUserDetailsService.java
@@ -1,4 +1,38 @@
 package oba.backend.server.security;
 
-public class CustomUserDetailsService {
+import lombok.RequiredArgsConstructor;
+import oba.backend.server.entity.Member;
+import oba.backend.server.repository.MemberRepository;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    // Spring Security는 내부적으로 username이라는 파라미터명을 사용하므로 메소드명은 그대로 둡니다.
+    // 하지만 실제로는 email을 사용하여 사용자를 조회합니다.
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return memberRepository.findByEmailAndIsWithdrawnFalse(email)
+                .map(this::createUserDetails)
+                .orElseThrow(() -> new UsernameNotFoundException(email + " -> 데이터베이스에서 찾을 수 없습니다."));
+    }
+
+    // DB 에 User 값이 존재한다면 UserDetails 객체로 만들어서 리턴
+    // User 객체의 첫 번째 인자인 username 필드에 email을 사용합니다.
+    private UserDetails createUserDetails(Member member) {
+        return new User(
+                member.getEmail(), // username 대신 email 사용
+                member.getPassword(),
+                Collections.singletonList(() -> "ROLE_USER")
+        );
+    }
 }

--- a/server/src/main/java/oba/backend/server/service/AuthService.java
+++ b/server/src/main/java/oba/backend/server/service/AuthService.java
@@ -1,4 +1,123 @@
 package oba.backend.server.service;
 
+import lombok.RequiredArgsConstructor;
+import oba.backend.server.dto.AuthDto.LoginRequest;
+import oba.backend.server.dto.AuthDto.SignUpRequest;
+import oba.backend.server.dto.AuthDto.TokenResponse;
+import oba.backend.server.entity.Member;
+import oba.backend.server.jwt.JwtProvider;
+import oba.backend.server.repository.MemberRepository;
+import oba.backend.server.security.CustomUserDetailsService;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final AuthenticationManager authenticationManager;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Transactional
+    public void signUp(SignUpRequest signUpRequest) {
+        // 1. 이메일로 회원 조회 (탈퇴 여부 무관)
+        Optional<Member> existingMemberByEmail = memberRepository.findByEmail(signUpRequest.email());
+        if (existingMemberByEmail.isPresent()) {
+            if (existingMemberByEmail.get().isWithdrawn()) {
+                throw new RuntimeException("탈퇴한 이력이 있는 이메일입니다. 다른 이메일을 사용해주세요.");
+            } else {
+                throw new RuntimeException("이미 사용 중인 이메일입니다.");
+            }
+        }
+
+        // 2. 닉네임으로 회원 조회 (탈퇴 여부 무관)
+        Optional<Member> existingMemberByNickname = memberRepository.findByNickname(signUpRequest.nickname());
+        if (existingMemberByNickname.isPresent()) {
+            throw new RuntimeException("이미 사용 중인 닉네임입니다.");
+        }
+
+        // 3. 중복이 없으면 회원가입 진행
+        String encodedPassword = passwordEncoder.encode(signUpRequest.password());
+        Member member = Member.builder()
+                .email(signUpRequest.email())
+                .nickname(signUpRequest.nickname())
+                .password(encodedPassword)
+                .build();
+        memberRepository.save(member);
+    }
+
+    @Transactional
+    public void deleteMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new RuntimeException("인증 정보가 없는 요청입니다.");
+        }
+        String email = authentication.getName();
+
+        Member member = memberRepository.findByEmailAndIsWithdrawnFalse(email)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        member.withdraw();
+    }
+
+    @Transactional
+    public TokenResponse login(LoginRequest loginRequest) {
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(loginRequest.email(), loginRequest.password());
+
+        Authentication authentication = authenticationManager.authenticate(authenticationToken);
+
+        TokenResponse tokenResponse = jwtProvider.generateToken(authentication);
+
+        Member member = memberRepository.findByEmailAndIsWithdrawnFalse(authentication.getName())
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+        member.updateRefreshToken(tokenResponse.refreshToken());
+
+        return tokenResponse;
+    }
+
+    @Transactional
+    public TokenResponse reissue(String refreshToken) {
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new RuntimeException("유효하지 않은 Refresh Token 입니다.");
+        }
+
+        Member member = memberRepository.findByRefreshTokenAndIsWithdrawnFalse(refreshToken)
+                .orElseThrow(() -> new RuntimeException("로그아웃 된 사용자입니다. 다시 로그인해주세요."));
+
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(member.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        TokenResponse tokenResponse = jwtProvider.generateToken(authentication);
+
+        member.updateRefreshToken(tokenResponse.refreshToken());
+
+        return tokenResponse;
+    }
+
+    @Transactional
+    public void logout() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new RuntimeException("인증 정보가 없는 요청입니다.");
+        }
+        String email = authentication.getName();
+
+        Member member = memberRepository.findByEmailAndIsWithdrawnFalse(email)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        member.updateRefreshToken(null);
+    }
 }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,1 +1,17 @@
 spring.application.name=server
+
+# MySQL Datasource Settings
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/oba_db?serverTimezone=Asia/Seoul
+spring.datasource.username=root
+spring.datasource.password=root
+#spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+
+
+# JWT Settings
+jwt.secret=0Ahuc+7bIl45KhET2va9ymahSlYQLeXDx9W6VpI4EW1YzN3CE72axw/YyCr1xJCVdtqaNPV9yq8YIhhxva03sQ==
+
+jwt.access-token-expiration-ms=1800000
+jwt.refresh-token-expiration-ms=604800000

--- a/server/src/test/java/oba/backend/server/service/AuthServiceTest.java
+++ b/server/src/test/java/oba/backend/server/service/AuthServiceTest.java
@@ -1,0 +1,242 @@
+package oba.backend.server.service;
+
+import oba.backend.server.dto.AuthDto.LoginRequest;
+import oba.backend.server.dto.AuthDto.SignUpRequest;
+import oba.backend.server.dto.AuthDto.TokenResponse;
+import oba.backend.server.entity.Member;
+import oba.backend.server.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private SignUpRequest signUpRequest;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 회원가입 DTO를 email, nickname 기반으로 수정
+        signUpRequest = new SignUpRequest("test@example.com", "testuser", "Password123!");
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공: 올바른 정보로 가입 시 DB에 정상적으로 저장된다.")
+    void signUp_success() {
+        // when
+        authService.signUp(signUpRequest);
+
+        // then
+        // email로 사용자를 조회
+        Member foundMember = memberRepository.findByEmailAndIsWithdrawnFalse("test@example.com")
+                .orElseThrow(() -> new AssertionError("테스트 실패: 사용자를 찾을 수 없습니다."));
+
+        // email과 nickname이 일치하는지 확인
+        assertThat(foundMember.getEmail()).isEqualTo("test@example.com");
+        assertThat(foundMember.getNickname()).isEqualTo("testuser");
+        assertTrue(passwordEncoder.matches("Password123!", foundMember.getPassword()));
+        assertFalse(foundMember.isWithdrawn());
+    }
+
+    @Test
+    @DisplayName("회원가입 실패: 이미 존재하는 (활성) 이메일로 가입을 시도하면 예외가 발생한다.")
+    void signUp_fail_duplicateEmail() {
+        // given
+        authService.signUp(signUpRequest); // 먼저 'test@example.com'으로 가입
+        SignUpRequest duplicateEmailRequest = new SignUpRequest("test@example.com", "newuser", "Password123!");
+
+        // when & then
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            authService.signUp(duplicateEmailRequest);
+        });
+        assertThat(exception.getMessage()).isEqualTo("이미 사용 중인 이메일입니다.");
+    }
+
+    @Test
+    @DisplayName("회원가입 실패: 탈퇴한 회원의 이메일로 가입을 시도하면 예외가 발생한다.")
+    void signUp_fail_emailOfWithdrawnUser() {
+        // given
+        // 1. 사용자를 가입시킨다.
+        authService.signUp(signUpRequest);
+        // 2. 해당 사용자를 탈퇴 처리한다 (Soft Delete).
+        Member member = memberRepository.findByEmail("test@example.com").get();
+        member.withdraw();
+        memberRepository.save(member);
+
+        // 3. 탈퇴한 회원의 이메일과 동일한 이메일로 가입을 시도한다. (닉네임은 다르게)
+        SignUpRequest withdrawnEmailRequest = new SignUpRequest("test@example.com", "anotheruser", "Password123!");
+
+        // when & then
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            authService.signUp(withdrawnEmailRequest);
+        });
+        // 상세한 예외 메시지가 발생하는지 확인한다.
+        assertThat(exception.getMessage()).isEqualTo("탈퇴한 이력이 있는 이메일입니다. 다른 이메일을 사용해주세요.");
+    }
+
+
+    @Test
+    @DisplayName("회원가입 실패: 이미 존재하는 닉네임으로 가입을 시도하면 예외가 발생한다.")
+    void signUp_fail_duplicateNickname() {
+        // given
+        authService.signUp(signUpRequest); // 먼저 'testuser' 닉네임으로 가입
+        SignUpRequest duplicateNicknameRequest = new SignUpRequest("new@example.com", "testuser", "Password123!");
+
+        // when & then
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            authService.signUp(duplicateNicknameRequest);
+        });
+        assertThat(exception.getMessage()).isEqualTo("이미 사용 중인 닉네임입니다.");
+    }
+
+
+    @Test
+    @DisplayName("로그인 성공: 올바른 이메일과 비밀번호로 로그인하면 토큰이 발급된다.")
+    void login_success() {
+        // given
+        authService.signUp(signUpRequest);
+        LoginRequest loginRequest = new LoginRequest("test@example.com", "Password123!");
+
+        // when
+        TokenResponse tokenResponse = authService.login(loginRequest);
+
+        // then
+        assertThat(tokenResponse).isNotNull();
+        assertThat(tokenResponse.accessToken()).isNotBlank();
+        assertThat(tokenResponse.refreshToken()).isNotBlank();
+
+        Member member = memberRepository.findByEmailAndIsWithdrawnFalse("test@example.com").get();
+        assertThat(member.getRefreshToken()).isEqualTo(tokenResponse.refreshToken());
+    }
+
+    @Test
+    @DisplayName("로그인 실패: 잘못된 비밀번호로 로그인하면 예외가 발생한다.")
+    void login_fail_wrongPassword() {
+        // given
+        authService.signUp(signUpRequest);
+        LoginRequest loginRequest = new LoginRequest("test@example.com", "WrongPassword123!");
+
+        // when & then
+        assertThrows(BadCredentialsException.class, () -> {
+            authService.login(loginRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("로그인 실패: 탈퇴한 회원으로 로그인하면 예외가 발생한다.")
+    void login_fail_withdrawnUser() {
+        // given
+        authService.signUp(signUpRequest);
+        Member member = memberRepository.findByEmailAndIsWithdrawnFalse("test@example.com").get();
+        member.withdraw();
+        memberRepository.save(member);
+
+        LoginRequest loginRequest = new LoginRequest("test@example.com", "Password123!");
+
+        // when & then
+        assertThrows(BadCredentialsException.class, () -> {
+            authService.login(loginRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공: 유효한 Refresh Token으로 재발급을 요청하면 새로운 토큰들이 발급된다.")
+    void reissue_success() throws InterruptedException {
+        // given
+        authService.signUp(signUpRequest);
+        LoginRequest loginRequest = new LoginRequest("test@example.com", "Password123!");
+        TokenResponse initialTokenResponse = authService.login(loginRequest);
+        String initialRefreshToken = initialTokenResponse.refreshToken();
+
+        Thread.sleep(1000);
+
+        // when
+        TokenResponse reissuedTokenResponse = authService.reissue(initialRefreshToken);
+
+        // then
+        assertThat(reissuedTokenResponse).isNotNull();
+        assertThat(reissuedTokenResponse.accessToken()).isNotEqualTo(initialTokenResponse.accessToken());
+        assertThat(reissuedTokenResponse.refreshToken()).isNotEqualTo(initialTokenResponse.refreshToken());
+
+        Member member = memberRepository.findByEmailAndIsWithdrawnFalse("test@example.com").get();
+        assertThat(member.getRefreshToken()).isEqualTo(reissuedTokenResponse.refreshToken());
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 성공 (Soft Delete): 탈퇴 요청 시 isWithdrawn이 true로 변경된다.")
+    void deleteMember_success_softDelete() {
+        // given
+        authService.signUp(signUpRequest);
+        LoginRequest loginRequest = new LoginRequest("test@example.com", "Password123!");
+        authService.login(loginRequest);
+
+        // SecurityContext에 email을 principal로 하는 인증 정보 설정
+        Authentication authentication = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                "test@example.com", null, java.util.Collections.singletonList(() -> "ROLE_USER"));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when
+        authService.deleteMember();
+
+        // then
+        assertFalse(memberRepository.findByEmailAndIsWithdrawnFalse("test@example.com").isPresent());
+
+        Member withdrawnMember = memberRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("test@example.com"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("테스트 실패: 탈퇴한 사용자를 DB에서 찾을 수 없습니다."));
+
+        assertTrue(withdrawnMember.isWithdrawn());
+        assertThat(withdrawnMember.getRefreshToken()).isNull();
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공: 로그아웃 요청 시 DB의 Refresh Token이 null로 변경된다.")
+    void logout_success() {
+        // given
+        authService.signUp(signUpRequest);
+        LoginRequest loginRequest = new LoginRequest("test@example.com", "Password123!");
+        authService.login(loginRequest);
+
+        Member memberBeforeLogout = memberRepository.findByEmailAndIsWithdrawnFalse("test@example.com").get();
+        assertThat(memberBeforeLogout.getRefreshToken()).isNotNull();
+
+        // SecurityContext에 email을 principal로 하는 인증 정보 설정
+        Authentication authentication = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                "test@example.com", null, java.util.Collections.singletonList(() -> "ROLE_USER"));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when
+        authService.logout();
+
+        // then
+        Member memberAfterLogout = memberRepository.findByEmailAndIsWithdrawnFalse("test@example.com").get();
+        assertThat(memberAfterLogout.getRefreshToken()).isNull();
+    }
+}


### PR DESCRIPTION
## 🚀 연관된 이슈
Closes: #1

---

## 📄 작업 내용
JWT 기반의 사용자 인증/인가 시스템의 핵심 기능을 구현하고, 서비스 정책에 맞춰 기능을 개선했습니다.  
`develop` 브랜치에 병합(merge)을 요청합니다.

---

## ✨ 변경 내용

- [x] **JWT 기반 핵심 인증 API 구현**
  - `POST /api/auth/signup`: 회원가입
  - `POST /api/auth/login`: 로그인 (Access/Refresh Token 발급)
  - `POST /api/auth/logout`: 로그아웃
  - `DELETE /api/auth/withdraw`: 회원 탈퇴
  - `POST /api/auth/reissue`: Access/Refresh 토큰 재발급

- [x] **사용자 식별자 변경 (username → email, nickname)**  
  - 로그인을 위한 `email`과 화면에 표시될 `nickname` 필드로 분리하여 확장성 확보

- [x] **Soft Delete (논리적 삭제) 도입**  
  - 회원 탈퇴 시 `is_withdrawn` 플래그를 `true`로 변경하는 방식으로 사용자 데이터 보존

- [x] **Refresh Token 저장소 확정 (MySQL)**  
  - 논의되었던 Redis 대신, 프로젝트 단계에 맞춰 `MySQL DB`에 저장하도록 최종 구현

- [x] **중복 가입 방지 로직 강화**  
  - 회원가입 시 활성/탈퇴 사용자를 모두 포함하여 이메일과 닉네임 중복 검사
  - 상황에 맞는 상세 예외 메시지를 반환하도록 개선

- [x] **단위 테스트 코드 작성**  
  - 위 모든 기능 변경사항을 검증하기 위한 `AuthServiceTest`를 최신화하여 코드 안정성 확보

---

## 📸 스크린샷
>  
AuthServiceTest 실행 결과
<img width="664" height="348" alt="image" src="https://github.com/user-attachments/assets/b0dd8077-9e08-4e0d-b813-b5d9accea795" />

POST
http://localhost:8080/api/auth/signup
<img width="1148" height="547" alt="image" src="https://github.com/user-attachments/assets/dba67de8-a042-4624-9c68-02d011e6860d" />
<img width="1148" height="90" alt="image" src="https://github.com/user-attachments/assets/1ba24e70-1700-462b-be0a-39644df39565" />

POST
http://localhost:8080/api/auth/login
<img width="1135" height="639" alt="image" src="https://github.com/user-attachments/assets/4ae06d93-886e-4df5-baa7-4657443ba178" />
<img width="1151" height="85" alt="image" src="https://github.com/user-attachments/assets/9dfca50b-12df-475d-b1ac-c64e13290e24" />

POST
http://localhost:8080/api/auth/reissue
<img width="1144" height="642" alt="image" src="https://github.com/user-attachments/assets/8e5d024a-fde3-4b1a-b7c5-5e9c00498094" />
<img width="1145" height="85" alt="image" src="https://github.com/user-attachments/assets/3190f87e-a399-426f-9f8c-bf139452ed08" />

DELETE
http://localhost:8080/api/auth/withdraw
<img width="1148" height="553" alt="image" src="https://github.com/user-attachments/assets/03f283f9-6f93-44ee-ab94-4b563f1d86ff" />
<img width="1141" height="77" alt="image" src="https://github.com/user-attachments/assets/2fabef8c-9c31-45b9-8c9b-6ecca13f2566" />


---

## ✅ 리뷰 요청 사항
1. `AuthService`의 **signUp 메소드 중복 검사 로직**이 서비스 정책에 부합하는지 확인 부탁드립니다.  
2. `Member` 엔티티의 **Soft Delete 방식(`is_withdrawn` 필드 및 `withdraw` 메소드)**이 적절하게 구현되었는지 검토 부탁드립니다.  
3. 전반적인 **코드 컨벤션**이나 더 효율적인 구현 방식에 대한 의견이 있으시면 자유롭게 남겨주세요!
